### PR TITLE
test: unit tests for transfers, balance, and adjustBalance

### DIFF
--- a/test/account/unit-tests/AccountTestBase.sol
+++ b/test/account/unit-tests/AccountTestBase.sol
@@ -123,8 +123,7 @@ contract AccountTestBase is Test {
         uint256 subId,
         int256 tokenAmounts
     ) internal {
-        AccountStructs.AssetTransfer[] memory transferBatch = new AccountStructs.AssetTransfer[](1);
-        transferBatch[0] = AccountStructs.AssetTransfer({
+        AccountStructs.AssetTransfer memory transfer = AccountStructs.AssetTransfer({
             fromAcc: fromAcc,
             toAcc: toAcc,
             asset: asset,
@@ -133,6 +132,6 @@ contract AccountTestBase is Test {
             assetData: bytes32(0)
         });
 
-        account.submitTransfers(transferBatch, "");
+        account.submitTransfer(transfer, "");
     }
 }

--- a/test/account/unit-tests/Allowance.t.sol
+++ b/test/account/unit-tests/Allowance.t.sol
@@ -14,7 +14,24 @@ contract UNIT_Allowances is Test, AccountTestBase {
     setUpAccounts();
   }
 
-  function testCannotTransferWithoutAllowance() public {    
+  function testCannotTransferWithoutPositiveAllowance() public {
+    int256 amount = 1e18;
+    vm.startPrank(alice);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAllowances.NotEnoughSubIdOrAssetAllowances.selector, 
+        address(account), 
+        alice,
+        bobAcc,
+        amount,
+        0,
+        0
+      )
+    );
+    transferToken(aliceAcc, bobAcc, usdcAsset, 0, amount);
+    vm.stopPrank();
+  }
+
+  function testCannotTradeWithoutAllowance() public {    
     // expect revert
     vm.startPrank(alice);
     vm.expectRevert(
@@ -31,7 +48,7 @@ contract UNIT_Allowances is Test, AccountTestBase {
     vm.stopPrank();
   }
 
-  function testTransferWithEnoughAssetAllowance() public {
+  function testTradeWithEnoughAssetAllowance() public {
     uint tradeAmount = 1e18;
 
     vm.startPrank(bob);
@@ -62,7 +79,7 @@ contract UNIT_Allowances is Test, AccountTestBase {
     assertEq(tokenAllowanceLeft, 0);
   }
 
-  function testTransferWithEnoughSubIdAllowance() public {
+  function testTradeWithEnoughSubIdAllowance() public {
     uint tradeAmount = 1e18;
 
     vm.startPrank(bob);
@@ -95,7 +112,7 @@ contract UNIT_Allowances is Test, AccountTestBase {
     assertEq(tokenAllowanceLeft, 0);
   }
 
-  function testTransferWithEnoughTotalAllowance() public {
+  function testTradeWithEnoughTotalAllowance() public {
     uint tradeAmount = 1e18;
 
     vm.startPrank(bob);
@@ -141,7 +158,7 @@ contract UNIT_Allowances is Test, AccountTestBase {
     assertEq(account.negativeAssetAllowance(bobAcc, bob, coolAsset, alice), 0);
   }
 
-  function testCannotTransferWithPartialNegativeAllowance() public {    
+  function testCannotTradeWithPartialNegativeAllowance() public {    
 
     vm.startPrank(bob);
     // bob allow alice to move its cool token, agree to receive USDC
@@ -192,7 +209,7 @@ contract UNIT_Allowances is Test, AccountTestBase {
     vm.stopPrank();
   }
 
-  function testCannotTransferWithInsufficientPositiveAllowance() public {    
+  function testCannotTradeWithInsufficientPositiveAllowance() public {    
     // trade will revert if receiver doesn't specify allowance to increase its position
     uint tradeAmount = 1e18;
 
@@ -254,7 +271,7 @@ contract UNIT_Allowances is Test, AccountTestBase {
     vm.stopPrank();
   }
 
-  function testCannotTransferBy3rdPartyWithoutAllowance() public {    
+  function testCannotTradeBy3rdPartyWithoutAllowance() public {    
     address orderbook = address(0xb00c);
 
     // bob give orderbook allowance over both

--- a/test/account/unit-tests/Basic.t.sol
+++ b/test/account/unit-tests/Basic.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+
+import "../../../src/interfaces/IAccount.sol";
+
+import {DumbManager} from "../../mocks/managers/DumbManager.sol";
+import {DumbAsset} from "../../mocks/assets/DumbAsset.sol";
+
+import {AccountTestBase} from "./AccountTestBase.sol";
+
+contract UNIT_AccountBasic is Test, AccountTestBase {
+
+  function setUp() public {
+    setUpAccounts();
+  } 
+
+  function testCannotTransferToSelf() public {
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccount.CannotTransferAssetToOneself.selector, 
+        address(account), 
+        alice,
+        aliceAcc
+      )
+    );
+    vm.prank(alice);
+    transferToken(aliceAcc, aliceAcc, usdcAsset, 0, 1e18);
+  }
+
+  // @note: do we want to allow this
+  function testCanTransferToAnyoneWith0Amount() public {
+    vm.prank(alice);
+    transferToken(aliceAcc, bobAcc, usdcAsset, 0, 0);
+  }
+
+  function testTransfersUpdateBalances() public {
+    // set allowance from bob and alice to allow trades
+    vm.prank(bob);
+    account.approve(address(this), bobAcc);
+    vm.prank(alice);
+    account.approve(address(this), aliceAcc);
+
+    int usdcAmount = 1e18;
+    int coolAmount = 2e18;
+
+    int aliceUsdcBefore = account.getBalance(aliceAcc, usdcAsset, 0);
+    int bobUsdcBefore = account.getBalance(bobAcc, usdcAsset, 0);
+
+    int aliceCoolBefore = account.getBalance(aliceAcc, coolAsset, tokenSubId);
+    int bobCoolBefore = account.getBalance(bobAcc, coolAsset, tokenSubId);
+
+    AccountStructs.AssetBalance[] memory aliceBalances = account.getAccountBalances(aliceAcc);
+    AccountStructs.AssetBalance[] memory bobBalances = account.getAccountBalances(bobAcc);
+    assertEq(aliceBalances.length, 1);
+    assertEq(bobBalances.length, 1);
+
+    tradeTokens(aliceAcc, bobAcc, address(usdcAsset), address(coolAsset), uint(usdcAmount), uint(coolAmount), 0, tokenSubId);
+
+    int aliceUsdcAfter = account.getBalance(aliceAcc, usdcAsset, 0);
+    int bobUsdcAfter = account.getBalance(bobAcc, usdcAsset, 0);
+
+    int aliceCoolAfter = account.getBalance(aliceAcc, coolAsset, tokenSubId);
+    int bobCoolAfter = account.getBalance(bobAcc, coolAsset, tokenSubId);
+
+    assertEq((aliceUsdcBefore - aliceUsdcAfter), usdcAmount);
+    assertEq((bobUsdcAfter - bobUsdcBefore), usdcAmount);
+    assertEq((aliceCoolAfter - aliceCoolBefore), coolAmount);
+    assertEq((bobCoolBefore - bobCoolAfter), coolAmount);
+
+    // requesting AssetBalance should also return new data
+    aliceBalances = account.getAccountBalances(aliceAcc);
+    bobBalances = account.getAccountBalances(bobAcc);
+    assertEq(aliceBalances.length, 2);
+    assertEq(bobBalances.length, 2);
+
+    assertEq(address(aliceBalances[1].asset), address(coolAsset));
+    assertEq(aliceBalances[1].subId, tokenSubId);
+    assertEq(aliceBalances[1].balance, coolAmount);
+
+    assertEq(address(bobBalances[1].asset), address(usdcAsset));
+    assertEq(bobBalances[1].subId, 0);
+    assertEq(bobBalances[1].balance, usdcAmount);
+  }
+
+  /** ========================================================== 
+   * tests for call flow rom Manager => Account.adjustBalance() |
+   * ========================================================== **/
+
+  function testCanAdjustBalanceFromManager() public {
+    uint newAccount = account.createAccount(address(this), dumbManager);
+    int amount = 1000e18;
+
+    vm.prank(address(dumbManager));
+    account.managerAdjustment(AccountStructs.AssetAdjustment({
+        acc: newAccount, 
+        asset: usdcAsset, 
+        subId: 0,
+        amount: amount,
+        assetData: bytes32(0)
+    }));
+
+    assertEq(account.getBalance(newAccount, usdcAsset, 0), amount);
+  }
+
+  function testAssetCanRevertAdjustmentByBadManager() public {
+    uint newAccount = account.createAccount(address(this), dumbManager);
+    int amount = 1000e18;
+
+    // assume usdc now block adjustment from dumbManager
+    usdcAsset.setRevertAdjustmentFromManager(address(dumbManager), true);
+
+    vm.prank(address(dumbManager));
+    vm.expectRevert();
+    account.managerAdjustment(AccountStructs.AssetAdjustment({
+        acc: newAccount, 
+        asset: usdcAsset, 
+        subId: 0,
+        amount: amount,
+        assetData: bytes32(0)
+    }));
+  }
+
+  /** ========================================================= 
+   * tests for call flow rom Asset => Account.adjustBalance()  |
+   * ========================================================= **/
+
+  function testCanAdjustBalanceFromAsset() public {
+    uint newAccount = account.createAccount(address(this), dumbManager);
+    int amount = 1000e18;
+
+    // assume calls from usdc
+    vm.prank(address(usdcAsset));
+    account.assetAdjustment(AccountStructs.AssetAdjustment({
+        acc: newAccount, 
+        asset: usdcAsset, 
+        subId: 0,
+        amount: amount,
+        assetData: bytes32(0)
+    }), false, "");
+
+    assertEq(account.getBalance(newAccount, usdcAsset, 0), amount);
+  }
+
+  function testCannotAdjustBalanceForAnotherAsset() public {
+    uint newAccount = account.createAccount(address(this), dumbManager);
+    int amount = 1000e18;
+
+    // assume calls from coolAsset
+    vm.prank(address(coolAsset));
+
+    vm.expectRevert(abi.encodeWithSelector(
+      IAccount.OnlyAsset.selector, 
+      address(account), 
+      address(coolAsset), 
+      address(usdcAsset)
+    ));
+    account.assetAdjustment(AccountStructs.AssetAdjustment({
+        acc: newAccount, 
+        asset: usdcAsset, 
+        subId: 0,
+        amount: amount,
+        assetData: bytes32(0)
+    }), true, "");
+  }
+}

--- a/test/mocks/assets/DumbAsset.sol
+++ b/test/mocks/assets/DumbAsset.sol
@@ -20,6 +20,9 @@ contract DumbAsset is IAsset {
   bool recordMangerChangeCalls;
   uint public handleManagerCalled;
 
+  // mocked state to test reverting calls from bad manager
+  mapping(address => bool) revertFromManager;
+
   constructor(IERC20 token_, IAccount account_, bool allowNegative_){
     token = token_;
     account = account_;
@@ -57,8 +60,9 @@ contract DumbAsset is IAsset {
   }
 
   function handleAdjustment(
-    AccountStructs.AssetAdjustment memory adjustment, int preBal, IManager /*riskModel*/, address
+    AccountStructs.AssetAdjustment memory adjustment, int preBal, IManager _manager, address
   ) external view override returns (int finalBalance) {
+    if (revertFromManager[address(_manager)]) revert();
     int result = preBal + adjustment.amount;
     if (result < 0 && !allowNegative) revert("negative balance");
     return result;
@@ -69,6 +73,10 @@ contract DumbAsset is IAsset {
     if(recordMangerChangeCalls) handleManagerCalled += 1;
   }
 
+  function setRevertAdjustmentFromManager(address _manager, bool _revert) external {
+    revertFromManager[_manager] = _revert;
+  }
+
   function setRevertHandleManagerChange(bool _revert) external {
     revertHandleManagerChange = _revert;
   }
@@ -76,4 +84,5 @@ contract DumbAsset is IAsset {
   function setRecordManagerChangeCalls(bool _record) external {
     recordMangerChangeCalls = _record;
   }
+
 }


### PR DESCRIPTION
**Depending on #11 , need to be merged into #11 first, or be rebased after merging #11)**

Added a few more unit tests in `UNIT_AccountBasic`:
- [x] simple transfers revert cases
- [x] balances check after trades
- [x] asset and manager hook checks
- [x] access control on `assetAdjustment` and `managerAdjustment`
- [x] Bring coverage to 100%  🌟 