### PR TITLE
cicd: coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Run Coverage
         run: forge coverage --report lcov
       
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     directory: .
-      #     env_vars: OS,PYTHON
-      #     fail_ci_if_error: true
-      #     files: ./lcov.info
-      #     name: lyra-v2
-      #     verbose: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: .
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./lcov.info
+          name: lyra-v2
+          verbose: true


### PR DESCRIPTION
## Summary

Add coverage report to cicd process

## Details

* Need to specify `CODECOV_TOKEN` as github secret.
* Forge coverage is not tracking library coverage correctly, also it runs on all files including mocks and test utils, which would result in a lower coverage. But the report should still be an easy way to visualise line covered during a PR review. 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`
- [x] Ran `forge fmt`
- [x] Ran `forge test`
- [x] 100% test coverage on code changes