### PR TITLE
Run cicd on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
       - master
   pull_request:
     branches:
-      - "*"
-      - "cicd/github-tests"
+      - "**"
 
 jobs:
   ci-check:


### PR DESCRIPTION
## Summary

Using `**` instead of `*` to make sure workflows run on all branch PRs.