### PR TITLE
chore: update PCRM interface

### DIFF
--- a/src/interfaces/IPCRM.sol
+++ b/src/interfaces/IPCRM.sol
@@ -7,26 +7,29 @@ pragma solidity ^0.8.13;
  * @notice Risk Manager that controls transfer and margin requirements
  */
 interface IPCRM {
-  struct ExpiryHolding {
+  struct Portfolio {
+    /// cash amount or debt
+    int cash;
+    /// timestamp of expiry for all strike holdings
     uint expiry;
-    uint numStrikeHoldings;
-    StrikeHolding[] strikes;
+    /// # of strikes with active balances
+    uint numStrikesHeld;
+    /// array of strike holding details
+    Strike[] strikes;
   }
 
-  struct StrikeHolding {
+  struct Strike {
     uint64 strike;
     int64 calls;
     int64 puts;
     int64 forwards;
   }
 
-  function getSortedHoldings(uint accountId) external view returns (ExpiryHolding[] memory expiryHoldings, int cash);
-
-  function getGroupedHoldings(uint accountId) external view returns (ExpiryHolding[] memory expiryHoldings);
+  function getPortfolio(uint accountId) external view returns (Portfolio memory portfolio);
 
   function executeBid(uint accountId, uint liquidatorId, uint portion, uint cashAmount)
     external
-    returns (int finalInitialMargin, ExpiryHolding[] memory, int cash);
+    returns (int finalInitialMargin, Portfolio[] memory, int cash);
 
   function getSpot() external view returns (uint spot);
 
@@ -38,8 +41,5 @@ interface IPCRM {
 
   function getCashAmount(uint accountId) external view returns (int);
 
-  function getInitialMarginForPortfolio(IPCRM.ExpiryHolding[] memory invertedExpiryHoldings)
-    external
-    view
-    returns (int);
+  function getInitialMarginForPortfolio(Portfolio memory portfolio) external view returns (int);
 }

--- a/test/shared/mocks/MockIPCRM.sol
+++ b/test/shared/mocks/MockIPCRM.sol
@@ -26,7 +26,7 @@ contract MockIPCRM is IPCRM, IManager {
 
   // next init margin that should be returned when calling getInitialMarginForPortfolio
   int public portMargin;
-  ExpiryHolding[] public userAcc; // just a result that can be set to be returned when testing
+  Portfolio public userAcc; // just a result that can be set to be returned when testing
 
   // if set to true, assume next executeBid will bring init margin to 0
   bool nextIsEndingBid = false;
@@ -35,21 +35,12 @@ contract MockIPCRM is IPCRM, IManager {
     account = _account;
   }
 
-  function getSortedHoldings(uint accountId)
-    external
-    view
-    virtual
-    returns (ExpiryHolding[] memory expiryHoldings, int cash)
-  {
-    // TODO: filler code
-  }
-
   // TODO: needs to be expanded upon next sprint to make sure that
   // it can handle the insolvency case properly
   function executeBid(uint accountId, uint liquidatorId, uint portion, uint cashAmount)
     external
     virtual
-    returns (int finalInitialMargin, ExpiryHolding[] memory, int cash)
+    returns (int finalInitialMargin, Portfolio[] memory, int cash)
   {
     if (cashAmount > 0) {
       initMargin[accountId] += cashAmount.toInt256();
@@ -86,23 +77,18 @@ contract MockIPCRM is IPCRM, IManager {
     return 0;
   }
 
-  function getGroupedHoldings(uint accountId) external view virtual returns (ExpiryHolding[] memory expiryHoldings) {
+  function getPortfolio(uint accountId) external view virtual returns (Portfolio memory portfolio) {
     // TODO: filler code
     if (accHasAssets[accountId]) {
-      ExpiryHolding[] memory expiryHoldings = new ExpiryHolding[](1);
-      StrikeHolding[] memory strikeHoldings = new StrikeHolding[](4);
+      Strike[] memory strikeHoldings = new Strike[](4);
 
-      strikeHoldings[0] = StrikeHolding(1000, 1, 1, 1);
-      strikeHoldings[1] = StrikeHolding(2000, 3, -1, 1);
-      strikeHoldings[2] = StrikeHolding(3000, 4, -2, 1);
-      strikeHoldings[3] = StrikeHolding(4000, 5, 10, 1);
+      strikeHoldings[0] = Strike(1000, 1, 1, 1);
+      strikeHoldings[1] = Strike(2000, 3, -1, 1);
+      strikeHoldings[2] = Strike(3000, 4, -2, 1);
+      strikeHoldings[3] = Strike(4000, 5, 10, 1);
 
-      expiryHoldings[0] = ExpiryHolding(block.timestamp + 2 weeks, 4, strikeHoldings);
-      return expiryHoldings;
+      portfolio = Portfolio(0, block.timestamp + 2 weeks, 4, strikeHoldings);
     }
-
-    ExpiryHolding[] memory expiryHoldings = new ExpiryHolding[](0);
-    return expiryHoldings;
   }
 
   function getCashAmount(uint accountId) external view virtual returns (int) {
@@ -135,19 +121,16 @@ contract MockIPCRM is IPCRM, IManager {
     accHasAssets[accountId] = true;
   }
 
-  function givePortfolio(uint accountId, ExpiryHolding[] memory expiryHoldings) external {
+  function givePortfolio(uint accountId, Portfolio memory portfolio) external {
     accHasAssets[accountId] = true;
 
-    // copy expiryHoldings into userAcc
-    for (uint i = 0; i < expiryHoldings.length; i++) {
-      userAcc[i].expiry = expiryHoldings[i].expiry;
-      userAcc[i].numStrikeHoldings = expiryHoldings[i].numStrikeHoldings;
-      for (uint j = 0; j < expiryHoldings[i].strikes.length; j++) {
-        userAcc[i].strikes[j].strike = expiryHoldings[i].strikes[j].strike;
-        userAcc[i].strikes[j].calls = expiryHoldings[i].strikes[j].calls;
-        userAcc[i].strikes[j].puts = expiryHoldings[i].strikes[j].puts;
-        userAcc[i].strikes[j].forwards = expiryHoldings[i].strikes[j].forwards;
-      }
+    userAcc.expiry = portfolio.expiry;
+    userAcc.numStrikesHeld = portfolio.numStrikesHeld;
+    for (uint i = 0; i < portfolio.strikes.length; i++) {
+      userAcc.strikes[i].strike = portfolio.strikes[i].strike;
+      userAcc.strikes[i].calls = portfolio.strikes[i].calls;
+      userAcc.strikes[i].puts = portfolio.strikes[i].puts;
+      userAcc.strikes[i].forwards = portfolio.strikes[i].forwards;
     }
   }
 
@@ -155,7 +138,7 @@ contract MockIPCRM is IPCRM, IManager {
     portMargin = margin;
   }
 
-  function getInitialMarginForPortfolio(IPCRM.ExpiryHolding[] memory) external view returns (int) {
+  function getInitialMarginForPortfolio(IPCRM.Portfolio memory) external view returns (int) {
     return portMargin;
   }
 


### PR DESCRIPTION
## Summary

Remove expiry and update interface for Dutch auction, make the merge easier

## Details
* the `_inversePortfolio` function was implemented in a way that it will change the input array in memory. So i removed the duplicated "return" variable and make it clearer it's  update in memory.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Add [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) for all functions / parameters
- [x] Ran `forge snapshot`
- [x] Ran `forge fmt`
- [x] Ran `forge test`
- [x] [Triage Slither issues](../README.md#triage-issues), and post uncertain ones in the PR
- [x] 100% test coverage on code changes

### Slither Issues (Optional)

If you're unsure about a new issue reported by Slither, copy them here so others can verify as well.