### PR TITLE
feat: bypass IM check if only depositing Cash

### DIFF
--- a/src/risk-managers/PCRM.sol
+++ b/src/risk-managers/PCRM.sol
@@ -127,6 +127,9 @@ contract PCRM is BaseManager, IManager, Owned, IPCRM {
   {
     // todo [Josh]: whitelist check
 
+    // bypass the IM check if only adding cash
+    if (assetDeltas.length == 1 && assetDeltas[0].asset == cashAsset && assetDeltas[0].delta >= 0) return;
+
     _chargeOIFee(accountId, feeRecipientAcc, tradeId, assetDeltas);
 
     // PCRM calculations


### PR DESCRIPTION
## Summary

We want to bypass the deposit check if incoming asset is cash, and amount >= 0. Just so we can:
* add margin when the account is under init margin but above maintenance margin to avoid liquidation
* add 0 cash to account to reflect the "real balance" after accruing interest.


## Todo

- [x] implementation
- [x] full coverage

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Add [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) for all functions / parameters
- [x] Ran `forge snapshot`
- [x] Ran `forge fmt`
- [x] Ran `forge test`
- [x] [Triage Slither issues](../README.md#triage-issues), and post uncertain ones in the PR
- [x] 100% test coverage on code changes

### Slither Issues (Optional)

If you're unsure about a new issue reported by Slither, copy them here so others can verify as well.