### PR TITLE
Feat (Accounts): Submit transfers fix

### DIFF
--- a/src/Accounts.sol
+++ b/src/Accounts.sol
@@ -388,6 +388,7 @@ contract Accounts is Allowances, ERC721, EIP712, IAccounts {
     tradeId = ++lastTradeId;
 
     for (uint i; i < assetTransfers.length; ++i) {
+      if (assetTransfers[i].fromAcc == 0 && assetTransfers[i].toAcc == 0) continue;
       // if from or to account is not seens before, add to seenAccounts in memory
       (uint fromIndex, uint toIndex) = (0, 0);
       (nextSeenId, fromIndex) =


### PR DESCRIPTION
## Summary

Issue: If an AssetTransfer[] contains an empty transfer after an amount of valid transfers the whole call will revert. We would like those empty transfers to be skipped.

## Todo

- [x] Skip empty transfers in a batch of transfers

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Add [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) for all functions / parameters
- [x] Ran `forge snapshot`
- [x] Ran `forge fmt`
- [x] Ran `forge test`
- [x] [Triage Slither issues](../README.md#triage-issues), and post uncertain ones in the PR
- [x] 100% test coverage on code changes

### Slither Issues (Optional)

If you're unsure about a new issue reported by Slither, copy them here so others can verify as well.