### PR TITLE
chore: use explicit import

### DIFF
--- a/src/Accounts.sol
+++ b/src/Accounts.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.18;
 
 import "openzeppelin/token/ERC721/ERC721.sol";
 import "openzeppelin/utils/math/SafeCast.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "openzeppelin/utils/cryptography/EIP712.sol";
 import "openzeppelin/utils/cryptography/SignatureChecker.sol";
 import "lyra-utils/arrays/UnorderedMemoryArray.sol";
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 import "./Allowances.sol";
 import "./libraries/AssetDeltaLib.sol";
 import "./libraries/PermitAllowanceLib.sol";

--- a/src/Allowances.sol
+++ b/src/Allowances.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.18;
 
 import "lyra-utils/math/IntLib.sol";
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAllowances.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAllowances} from "src/interfaces/IAllowances.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 /**
  * @title Allowacne

--- a/src/SecurityModule.sol
+++ b/src/SecurityModule.sol
@@ -9,11 +9,12 @@ import "lyra-utils/decimals/DecimalMath.sol";
 import "lyra-utils/decimals/ConvertDecimals.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
-import "src/interfaces/IPCRM.sol";
-import "src/interfaces/ICashAsset.sol";
-import "src/interfaces/ISecurityModule.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IPCRM} from "src/interfaces/IPCRM.sol";
+import {ICashAsset} from "src/interfaces/ICashAsset.sol";
+import {ISecurityModule} from "src/interfaces/ISecurityModule.sol";
 
 /**
  * @title SecurityModule

--- a/src/assets/CashAsset.sol
+++ b/src/assets/CashAsset.sol
@@ -10,9 +10,10 @@ import "lyra-utils/decimals/DecimalMath.sol";
 import "lyra-utils/decimals/ConvertDecimals.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAccounts.sol";
-import "src/interfaces/ICashAsset.sol";
-import "src/interfaces/IInterestRateModel.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {ICashAsset} from "src/interfaces/ICashAsset.sol";
+import {IInterestRateModel} from "src/interfaces/IInterestRateModel.sol";
 
 import "./ManagerWhitelist.sol";
 

--- a/src/assets/ManagerWhitelist.sol
+++ b/src/assets/ManagerWhitelist.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.18;
 
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/interfaces/IManagerWhitelist.sol";
 
 /**

--- a/src/assets/Option.sol
+++ b/src/assets/Option.sol
@@ -10,10 +10,11 @@ import "lyra-utils/math/IntLib.sol";
 
 import "./ManagerWhitelist.sol";
 
-import "src/interfaces/IOption.sol";
-import "src/interfaces/IChainlinkSpotFeed.sol";
-import "src/interfaces/IAccounts.sol";
-import "src/interfaces/ISettlementFeed.sol";
+import {IOption} from "src/interfaces/IOption.sol";
+import {IChainlinkSpotFeed} from "src/interfaces/IChainlinkSpotFeed.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {ISettlementFeed} from "src/interfaces/ISettlementFeed.sol";
 
 /**
  * @title Option

--- a/src/assets/PerpAsset.sol
+++ b/src/assets/PerpAsset.sol
@@ -13,9 +13,11 @@ import "lyra-utils/decimals/DecimalMath.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 import "lyra-utils/math/IntLib.sol";
 
-import "src/interfaces/IAccounts.sol";
-import "src/interfaces/IPerpAsset.sol";
-import "src/interfaces/IChainlinkSpotFeed.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IPerpAsset} from "src/interfaces/IPerpAsset.sol";
+import {IChainlinkSpotFeed} from "src/interfaces/IChainlinkSpotFeed.sol";
+
+import {IManager} from "src/interfaces/IManager.sol";
 
 import "./ManagerWhitelist.sol";
 

--- a/src/interfaces/IAccounts.sol
+++ b/src/interfaces/IAccounts.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.18;
 
 import "openzeppelin/token/ERC721/IERC721.sol";
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
-import "src/interfaces/IAllowances.sol";
+import {IAllowances} from "src/interfaces/IAllowances.sol";
 
 // For full documentation refer to src/Accounts.sol";
 interface IAccounts is IERC721 {

--- a/src/interfaces/IAllowances.sol
+++ b/src/interfaces/IAllowances.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 // For full documentation refer to src/Allowances.sol";
 interface IAllowances {

--- a/src/interfaces/IAsset.sol
+++ b/src/interfaces/IAsset.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 interface IAsset {
   /**

--- a/src/interfaces/IBasicManager.sol
+++ b/src/interfaces/IBasicManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 interface IBasicManager is IManager {
   ///@dev Struct for Perp Margin Requirements

--- a/src/interfaces/ICashAsset.sol
+++ b/src/interfaces/ICashAsset.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 import "src/interfaces/IInterestRateModel.sol";
 
 interface ICashAsset is IAsset {

--- a/src/interfaces/IChainlinkSpotFeed.sol
+++ b/src/interfaces/IChainlinkSpotFeed.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IFutureFeed.sol";
-import "src/interfaces/ISettlementFeed.sol";
+import {IFutureFeed} from "src/interfaces/IFutureFeed.sol";
+import {ISettlementFeed} from "src/interfaces/ISettlementFeed.sol";
 
 /**
  * @title IChainlinkSpotFeed

--- a/src/interfaces/IManager.sol
+++ b/src/interfaces/IManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 interface IManager {
   /**

--- a/src/interfaces/IOption.sol
+++ b/src/interfaces/IOption.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 import "src/interfaces/IInterestRateModel.sol";
 import "src/interfaces/ISettlementFeed.sol";
 

--- a/src/interfaces/IPCRM.sol
+++ b/src/interfaces/IPCRM.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IBaseManager.sol";
-import "src/interfaces/ISpotJumpOracle.sol";
+import {IBaseManager} from "src/interfaces/IBaseManager.sol";
+import {ISpotJumpOracle} from "src/interfaces/ISpotJumpOracle.sol";
 
 /**
  * @title PartialCollateralRiskManager

--- a/src/interfaces/IPerpAsset.sol
+++ b/src/interfaces/IPerpAsset.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 /**
  * @title IPerpAsset

--- a/src/libraries/AssetDeltaLib.sol
+++ b/src/libraries/AssetDeltaLib.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 /**
  * @title ArrayDeltaLib

--- a/src/libraries/PermitAllowanceLib.sol
+++ b/src/libraries/PermitAllowanceLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAllowances.sol";
+import {IAllowances} from "src/interfaces/IAllowances.sol";
 
 /**
  * @title PermitAllowanceLib

--- a/src/risk-managers/BaseManager.sol
+++ b/src/risk-managers/BaseManager.sol
@@ -7,12 +7,16 @@ import "lyra-utils/encoding/OptionEncoding.sol";
 import "lyra-utils/math/IntLib.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAccounts.sol";
-import "src/interfaces/IOption.sol";
-import "src/interfaces/IPerpAsset.sol";
-import "src/interfaces/ICashAsset.sol";
-import "src/interfaces/IFutureFeed.sol";
-import "src/interfaces/IBaseManager.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IOption} from "src/interfaces/IOption.sol";
+import {IPerpAsset} from "src/interfaces/IPerpAsset.sol";
+import {ICashAsset} from "src/interfaces/ICashAsset.sol";
+import {IFutureFeed} from "src/interfaces/IFutureFeed.sol";
+import {IBaseManager} from "src/interfaces/IBaseManager.sol";
+
+import {ISettlementFeed} from "src/interfaces/ISettlementFeed.sol";
+import {IFutureFeed} from "src/interfaces/IFutureFeed.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "src/libraries/StrikeGrouping.sol";
 

--- a/src/risk-managers/BasicManager.sol
+++ b/src/risk-managers/BasicManager.sol
@@ -9,17 +9,19 @@ import "lyra-utils/decimals/SignedDecimalMath.sol";
 import "lyra-utils/math/IntLib.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAccounts.sol";
-import "src/interfaces/ICashAsset.sol";
-import "src/interfaces/IPerpAsset.sol";
-import "src/interfaces/IBaseManager.sol";
-import "src/interfaces/IOption.sol";
-import "src/interfaces/IOptionPricing.sol";
-import "src/interfaces/IChainlinkSpotFeed.sol";
-import "src/interfaces/IBasicManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {ICashAsset} from "src/interfaces/ICashAsset.sol";
+import {IPerpAsset} from "src/interfaces/IPerpAsset.sol";
+import {IBaseManager} from "src/interfaces/IBaseManager.sol";
+import {IOption} from "src/interfaces/IOption.sol";
+import {IOptionPricing} from "src/interfaces/IOptionPricing.sol";
+import {IChainlinkSpotFeed} from "src/interfaces/IChainlinkSpotFeed.sol";
+import {IBasicManager} from "src/interfaces/IBasicManager.sol";
+import {IFutureFeed} from "src/interfaces/IFutureFeed.sol";
+import {ISettlementFeed} from "src/interfaces/ISettlementFeed.sol";
 
-import "./BaseManager.sol";
+import {BaseManager} from "./BaseManager.sol";
 
 import "forge-std/console2.sol";
 

--- a/src/risk-managers/MLRM.sol
+++ b/src/risk-managers/MLRM.sol
@@ -7,8 +7,8 @@ import "lyra-utils/decimals/DecimalMath.sol";
 import "lyra-utils/decimals/SignedDecimalMath.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/interfaces/IDutchAuction.sol";
 import "src/interfaces/ICashAsset.sol";
 

--- a/src/risk-managers/PCRM.sol
+++ b/src/risk-managers/PCRM.sol
@@ -6,8 +6,8 @@ import "openzeppelin/utils/math/SignedMath.sol";
 import "lyra-utils/math/Black76.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/interfaces/IDutchAuction.sol";
 import "src/interfaces/ICashAsset.sol";
 import "src/interfaces/IOption.sol";

--- a/test/account/mocks/assets/BaseWrapper.sol
+++ b/test/account/mocks/assets/BaseWrapper.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.18;
 import "openzeppelin/token/ERC20/IERC20.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 import "../feeds/PriceFeeds.sol";
 

--- a/test/account/mocks/assets/ISettleable.sol
+++ b/test/account/mocks/assets/ISettleable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 interface ISettleable is IAsset {
   // Are these controlled through the margin account contract or are they separate/users will have to adjust these themselves?

--- a/test/account/mocks/assets/OptionToken.sol
+++ b/test/account/mocks/assets/OptionToken.sol
@@ -9,7 +9,7 @@ import "forge-std/console2.sol";
 
 import "src/Accounts.sol";
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "../assets/QuoteWrapper.sol";
 import "../feeds/SettlementPricer.sol";

--- a/test/account/mocks/assets/QuoteWrapper.sol
+++ b/test/account/mocks/assets/QuoteWrapper.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 import "openzeppelin/token/ERC20/IERC20.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 import "src/Accounts.sol";
 
 import "../feeds/PriceFeeds.sol";

--- a/test/account/mocks/assets/lending/Lending.sol
+++ b/test/account/mocks/assets/lending/Lending.sol
@@ -7,9 +7,10 @@ import "lyra-utils/decimals/DecimalMath.sol";
 import "lyra-utils/decimals/SignedDecimalMath.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 import "./InterestRateModel.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 import "forge-std/console2.sol";
 

--- a/test/account/mocks/feeds/IVFeeds.sol
+++ b/test/account/mocks/feeds/IVFeeds.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 import "openzeppelin/access/Ownable2Step.sol";
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 // simple single IV oracle
 contract IVFeeds is Ownable2Step {

--- a/test/account/mocks/feeds/PriceFeeds.sol
+++ b/test/account/mocks/feeds/PriceFeeds.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 import "openzeppelin/access/Ownable2Step.sol";
-import "src/interfaces/IAsset.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 interface PriceFeeds {
   function assignFeedToAsset(IAsset asset, uint feedId) external;

--- a/test/account/mocks/managers/DumbManager.sol
+++ b/test/account/mocks/managers/DumbManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 import "../../../shared/mocks/MockManager.sol";
 

--- a/test/account/mocks/managers/PortfolioRiskPOCManager.sol
+++ b/test/account/mocks/managers/PortfolioRiskPOCManager.sol
@@ -9,8 +9,8 @@ import "openzeppelin/access/Ownable2Step.sol";
 
 import "forge-std/console2.sol";
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 import "./../assets/QuoteWrapper.sol";
 import "./../assets/BaseWrapper.sol";

--- a/test/account/poc-tests/AccountPOCHelper.sol
+++ b/test/account/poc-tests/AccountPOCHelper.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.18;
 
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 import "forge-std/Test.sol";
 import "forge-std/console2.sol";

--- a/test/account/unit-tests/Allowance.t.sol
+++ b/test/account/unit-tests/Allowance.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "forge-std/console2.sol";
 import "../../shared/mocks/MockERC20.sol";
 import "../../shared/mocks/MockAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/Allowances.sol";
 import "src/Accounts.sol";
 import {AccountTestBase} from "./AccountTestBase.sol";

--- a/test/assets/optionAsset/unit-tests/Basics.sol
+++ b/test/assets/optionAsset/unit-tests/Basics.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.18;
 import "forge-std/Test.sol";
 import "src/assets/Option.sol";
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockManager.sol";
 

--- a/test/assets/perpAsset/unit-tests/Funding.sol
+++ b/test/assets/perpAsset/unit-tests/Funding.sol
@@ -9,7 +9,7 @@ import "../../../shared/mocks/MockFeed.sol";
 
 import "src/Accounts.sol";
 import "src/assets/PerpAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/interfaces/IPerpAsset.sol";
 
 contract UNIT_PerpAssetFunding is Test {

--- a/test/assets/perpAsset/unit-tests/PNL.sol
+++ b/test/assets/perpAsset/unit-tests/PNL.sol
@@ -9,7 +9,7 @@ import "../../../shared/mocks/MockFeed.sol";
 
 import "src/Accounts.sol";
 import "src/assets/PerpAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/interfaces/IPerpAsset.sol";
 
 contract UNIT_PerpAssetPNL is Test {

--- a/test/auction/mocks/MockCashAsset.sol
+++ b/test/auction/mocks/MockCashAsset.sol
@@ -5,7 +5,7 @@ import "openzeppelin/token/ERC20/IERC20.sol";
 import "lyra-utils/decimals/DecimalMath.sol";
 
 import "src/interfaces/ICashAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "../../shared/mocks/MockAsset.sol";
 
 /**

--- a/test/integration-tests/assets/cashAsset/BorrowAgainstOptions.t.sol
+++ b/test/integration-tests/assets/cashAsset/BorrowAgainstOptions.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "forge-std/console2.sol";
 
 import "../../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev testing charge of OI fee in a real setting

--- a/test/integration-tests/assets/optionAsset/MultiwayTrade.t.sol
+++ b/test/integration-tests/assets/optionAsset/MultiwayTrade.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.18;
 
 import "forge-std/console2.sol";
 import "../../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev testing charge of OI fee in a real setting

--- a/test/integration-tests/liquidation/liquidation.t.sol
+++ b/test/integration-tests/liquidation/liquidation.t.sol
@@ -6,7 +6,7 @@ import "forge-std/console2.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
 import "../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev testing liquidation process

--- a/test/integration-tests/pcrm/invariants.sol
+++ b/test/integration-tests/pcrm/invariants.sol
@@ -6,7 +6,7 @@ import "forge-std/console2.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
 import "../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev testing some properties of PCRM

--- a/test/integration-tests/perp-manager/settle-perp.sol
+++ b/test/integration-tests/perp-manager/settle-perp.sol
@@ -14,7 +14,7 @@ import "src/risk-managers/BasicManager.sol";
 import "src/assets/PerpAsset.sol";
 import "src/assets/CashAsset.sol";
 import "src/assets/Option.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/interfaces/IPerpAsset.sol";
 
 /**

--- a/test/integration-tests/settlement/Settlement.t.sol
+++ b/test/integration-tests/settlement/Settlement.t.sol
@@ -6,7 +6,7 @@ import "forge-std/console2.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
 import "../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev testing settlement logic

--- a/test/integration-tests/shared/IntegrationTestBase.sol
+++ b/test/integration-tests/shared/IntegrationTestBase.sol
@@ -18,7 +18,7 @@ import "src/risk-managers/SpotJumpOracle.sol";
 import "test/feeds/mocks/MockV3Aggregator.sol";
 
 import "src/interfaces/IPCRM.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev real Accounts contract

--- a/test/integration-tests/shared/PositionBuilderBase.sol
+++ b/test/integration-tests/shared/PositionBuilderBase.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 import "forge-std/Test.sol";
 
 import "../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev a helper for building positions (e.g. leveraged boxes, zscs, etc.)

--- a/test/integration-tests/socialized-losses/socialize-losses.t.sol
+++ b/test/integration-tests/socialized-losses/socialize-losses.t.sol
@@ -6,7 +6,7 @@ import "forge-std/console2.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
 import "../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev insolvent auction leads to socialize losses

--- a/test/integration-tests/trade/OIFeeIntegration.t.sol
+++ b/test/integration-tests/trade/OIFeeIntegration.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
 import "../shared/IntegrationTestBase.sol";
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @dev testing charge of OI fee in a real setting

--- a/test/risk-managers/gas-tests/PCRMGroupingGasScript.t.sol
+++ b/test/risk-managers/gas-tests/PCRMGroupingGasScript.t.sol
@@ -7,8 +7,8 @@ import "src/risk-managers/PCRM.sol";
 import "src/assets/CashAsset.sol";
 import "src/assets/InterestRateModel.sol";
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockERC20.sol";
 import "test/shared/mocks/MockFeed.sol";

--- a/test/risk-managers/gas-tests/SpotJumpOracleGas.s.sol
+++ b/test/risk-managers/gas-tests/SpotJumpOracleGas.s.sol
@@ -7,8 +7,8 @@ import "src/assets/Option.sol";
 import "src/risk-managers/PCRM.sol";
 import "src/risk-managers/SpotJumpOracle.sol";
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 contract PCRMSpotJumpOracleGas is Script {
   Accounts account;

--- a/test/risk-managers/poc-tests/RouterPOC.sol
+++ b/test/risk-managers/poc-tests/RouterPOC.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 import "src/interfaces/IPCRM.sol";
 

--- a/test/risk-managers/unit-tests/TestBaseManager.t.sol
+++ b/test/risk-managers/unit-tests/TestBaseManager.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 import "forge-std/Test.sol";
 import "openzeppelin/token/ERC20/IERC20.sol";
 
-import "src/interfaces/IManager.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 import "src/interfaces/ICashAsset.sol";
 import "src/interfaces/IOption.sol";
 import "src/interfaces/IChainlinkSpotFeed.sol";

--- a/test/risk-managers/unit-tests/TestBasicManager_Option.t.sol
+++ b/test/risk-managers/unit-tests/TestBasicManager_Option.t.sol
@@ -7,8 +7,8 @@ import "src/risk-managers/BasicManager.sol";
 import "lyra-utils/encoding/OptionEncoding.sol";
 
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockManager.sol";
 import "test/shared/mocks/MockERC20.sol";

--- a/test/risk-managers/unit-tests/TestBasicManager_Perp.t.sol
+++ b/test/risk-managers/unit-tests/TestBasicManager_Perp.t.sol
@@ -5,8 +5,8 @@ import "forge-std/Test.sol";
 import "src/risk-managers/BasicManager.sol";
 
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockManager.sol";
 import "test/shared/mocks/MockERC20.sol";

--- a/test/risk-managers/unit-tests/TestMLRM.t.sol
+++ b/test/risk-managers/unit-tests/TestMLRM.t.sol
@@ -5,8 +5,8 @@ import "forge-std/Test.sol";
 import "src/risk-managers/MLRM.sol";
 import "src/assets/CashAsset.sol";
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockManager.sol";
 import "test/shared/mocks/MockERC20.sol";

--- a/test/risk-managers/unit-tests/TestPCRM.t.sol
+++ b/test/risk-managers/unit-tests/TestPCRM.t.sol
@@ -5,8 +5,8 @@ import "src/assets/Option.sol";
 import "src/risk-managers/PCRM.sol";
 import "src/assets/CashAsset.sol";
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockManager.sol";
 import "test/shared/mocks/MockERC20.sol";

--- a/test/risk-managers/unit-tests/TestPCRM_Admin.t.sol
+++ b/test/risk-managers/unit-tests/TestPCRM_Admin.t.sol
@@ -7,8 +7,8 @@ import "src/risk-managers/PCRM.sol";
 import "src/assets/CashAsset.sol";
 import "src/Accounts.sol";
 
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 import "src/interfaces/IChainlinkSpotFeed.sol";
 
 import "test/shared/mocks/MockManager.sol";

--- a/test/risk-managers/unit-tests/TestPCRM_OIFee.t.sol
+++ b/test/risk-managers/unit-tests/TestPCRM_OIFee.t.sol
@@ -7,8 +7,8 @@ import "src/assets/Option.sol";
 import "src/risk-managers/PCRM.sol";
 import "src/Accounts.sol";
 
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockERC20.sol";
 import "test/shared/mocks/MockAsset.sol";

--- a/test/risk-managers/unit-tests/TestPCRM_TimeWeighting.t.sol
+++ b/test/risk-managers/unit-tests/TestPCRM_TimeWeighting.t.sol
@@ -6,8 +6,8 @@ import "src/assets/Option.sol";
 import "src/risk-managers/PCRM.sol";
 import "src/assets/CashAsset.sol";
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 import "src/interfaces/IChainlinkSpotFeed.sol";
 
 import "test/shared/mocks/MockManager.sol";

--- a/test/risk-managers/unit-tests/TestSpotJumpOracle.sol
+++ b/test/risk-managers/unit-tests/TestSpotJumpOracle.sol
@@ -4,8 +4,8 @@ import "forge-std/Test.sol";
 import "src/risk-managers/SpotJumpOracle.sol";
 import "src/feeds/ChainlinkSpotFeed.sol";
 import "src/Accounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 import "test/shared/mocks/MockManager.sol";
 import "test/feeds/mocks/MockV3Aggregator.sol";

--- a/test/security-module/mocks/MockCash.sol
+++ b/test/security-module/mocks/MockCash.sol
@@ -7,8 +7,8 @@ import "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin/utils/math/SafeCast.sol";
 import "openzeppelin/access/Ownable2Step.sol";
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 import "src/interfaces/ICashAsset.sol";
 import "../../shared/mocks/MockAsset.sol";
 

--- a/test/shared/mocks/MockAsset.sol
+++ b/test/shared/mocks/MockAsset.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.18;
 import "openzeppelin/token/ERC20/IERC20.sol";
 import "lyra-utils/decimals/DecimalMath.sol";
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 /**
  * @title MockAsset is the easiest Asset wrapper that wraps ERC20 into account system.

--- a/test/shared/mocks/MockIPCRM.sol
+++ b/test/shared/mocks/MockIPCRM.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.18;
 
 import "src/interfaces/IPCRM.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
 
 import "openzeppelin/utils/math/SafeMath.sol";
 import "openzeppelin/utils/math/SafeCast.sol";

--- a/test/shared/mocks/MockManager.sol
+++ b/test/shared/mocks/MockManager.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IAsset.sol";
-import "src/interfaces/IAccounts.sol";
-import "forge-std/console2.sol";
-import "forge-std/console.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 import "lyra-utils/decimals/DecimalMath.sol";
 

--- a/test/shared/mocks/MockOption.sol
+++ b/test/shared/mocks/MockOption.sol
@@ -6,7 +6,8 @@ import "openzeppelin/utils/math/SafeCast.sol";
 import "lyra-utils/decimals/SignedDecimalMath.sol";
 
 import "src/interfaces/IOption.sol";
-import "src/interfaces/IAccounts.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
 
 contract MockOption is IOption {
   using SafeCast for uint;

--- a/test/shared/mocks/MockSM.sol
+++ b/test/shared/mocks/MockSM.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.18;
 
 import "src/interfaces/ISecurityModule.sol";
-import "src/interfaces/IAccounts.sol";
-import "src/interfaces/IManager.sol";
-import "src/interfaces/IAsset.sol";
+import {IAccounts} from "src/interfaces/IAccounts.sol";
+import {IManager} from "src/interfaces/IManager.sol";
+import {IAsset} from "src/interfaces/IAsset.sol";
 
 contract MockSM is ISecurityModule {
   IAccounts public immutable accounts;


### PR DESCRIPTION
## Summary

This was to solve the issue when a repo install `v2-core` and try to import the interfaces, it ran into circular dependencies because `IAccounts` import everything from `IAsset`, `IManager`, which also import everything from `IAccounts`.

By only importing 1 specific interface, it won't load other interfaces into the contract.
