### PR TITLE
fix: [Lyra02][critical] Liquidation can be blocked by transferring long options to the liquidator

### DIFF
--- a/src/assets/Option.sol
+++ b/src/assets/Option.sol
@@ -78,7 +78,8 @@ contract Option is IOption, PositionTracking, GlobalSubIdOITracking, ManagerWhit
     accountTotalPosition[adjustment.acc] =
       accountTotalPosition[adjustment.acc] + SignedMath.abs(postBalance) - SignedMath.abs(preBalance);
 
-    return (postBalance, adjustment.amount < 0);
+    // always need allowance: cannot force to send positive asset to other accounts
+    return (postBalance, true);
   }
 
   /**

--- a/src/assets/WrappedERC20Asset.sol
+++ b/src/assets/WrappedERC20Asset.sol
@@ -124,7 +124,8 @@ contract WrappedERC20Asset is ManagerWhitelist, PositionTracking, IWrappedERC20A
 
     if (finalBalance < 0) revert WERC_CannotBeNegative();
 
-    return (finalBalance, adjustment.amount < 0);
+    // always need allowance: cannot force to send positive asset to other accounts
+    return (finalBalance, true);
   }
 
   /**

--- a/test/shared/mocks/MockOption.sol
+++ b/test/shared/mocks/MockOption.sol
@@ -50,7 +50,7 @@ contract MockOption is MockPositionTracking, MockGlobalSubIdOITracking, IOption 
   ) public view virtual returns (int finalBalance, bool needAllowance) {
     if (revertFromManager[address(_manager)]) revert();
     finalBalance = preBal + adjustment.amount;
-    needAllowance = adjustment.amount < 0;
+    needAllowance = true;
   }
 
   function handleManagerChange(uint, IManager) public virtual {


### PR DESCRIPTION
## Summary
Bug description: liquidation can be blocked by sending all bidders a small amount of options, because we require liquidators to only have cash asset in his account.

## Solution
Ban transferring positive base asset and option asset without approvals (only allow positive cash)

## Implications:
user will need to "agree" receiving positive value option or base assets, if 2 accounts are own by different owners. This makes the UX slightly worse. 