### PR TITLE
fix: [Lyra04][high] Account can constructed to hold  malicious asset under a legit manager

### DIFF
--- a/test/risk-managers/unit-tests/PMRM/TestPMRM_Misc.t.sol
+++ b/test/risk-managers/unit-tests/PMRM/TestPMRM_Misc.t.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.8.18;
+
+import {ISubAccounts} from "../../../../src/interfaces/ISubAccounts.sol";
+import {IPMRM} from "../../../../src/interfaces/IPMRM.sol";
+import {MockManager} from "../../../shared/mocks/MockManager.sol";
+import {MockOption} from "../../../shared/mocks/MockOption.sol";
+
+import "../../../risk-managers/unit-tests/PMRM/utils/PMRMSimTest.sol";
+
+contract UNIT_TestPMRM_Misc is PMRMSimTest {
+  function testCannotChangeFromBadManagerWithInvalidAsset() public {
+    // create accounts with bad manager
+    MockManager badManager = new MockManager(address(subAccounts));
+    MockOption badAsset = new MockOption(subAccounts);
+    uint badAcc = subAccounts.createAccount(address(this), badManager);
+    uint badAcc2 = subAccounts.createAccount(address(this), badManager);
+
+    // create bad positions
+    ISubAccounts.AssetTransfer memory transfer = ISubAccounts.AssetTransfer({
+      fromAcc: badAcc,
+      toAcc: badAcc2,
+      asset: badAsset,
+      subId: 0,
+      amount: 100e18,
+      assetData: ""
+    });
+    subAccounts.submitTransfer(transfer, "");
+
+    // alice migrate to a our pmrm
+    vm.expectRevert(IPMRM.PMRM_UnsupportedAsset.selector);
+    subAccounts.changeManager(badAcc, pmrm, "");
+  }
+}


### PR DESCRIPTION
## Summary
By doing the following, anyone can create an account under PMRM or standard manager with malicious asset:
* create an account with a bad manager
* trade a bad asset
* change manager to PMRM or standard manager
Since the asset delta is [], the risk check is by passed, causing PMRM or standard manager to agree manage an account with a malicious asset. 

The attacker can then full the following 2 attacks:
1. revert all liquidations (let the bad asset revert on `executeBid`)
2. for PMRM specifically, merge another legit account into this account, causing all assets in this account to be untrade-able.

## Solution
The account should pass in the whole asset balance as `assetDelta` to the risk manager, by doing this, it let the managers not bypassing the risk check and indeed run a full check on all assets that is incoming.


