### PR TITLE
fix: [Lyra03][critical] Bidders can bid with 0 cash

### DIFF
--- a/src/interfaces/IDutchAuction.sol
+++ b/src/interfaces/IDutchAuction.sol
@@ -119,6 +119,9 @@ interface IDutchAuction {
   /// @dev emitted when a bid is submitted for 0% of the portfolio
   error DA_AmountIsZero();
 
+  /// @dev emitted when bidder doesn't have enough cash for bidding
+  error DA_InsufficientCash();
+
   /// @dev emitted when owner trying to set a invalid buffer margin param
   error DA_InvalidBufferMarginParameter();
 

--- a/src/liquidation/DutchAuction.sol
+++ b/src/liquidation/DutchAuction.sol
@@ -515,6 +515,9 @@ contract DutchAuction is IDutchAuction, Ownable2Step {
 
     cashFromBidder = bidPrice.toUint256().multiplyDecimal(percentLiquidated);
 
+    int bidderCashBalance = subAccounts.getBalance(bidderId, cash, 0);
+    if (bidderCashBalance.toUint256() < cashFromBidder) revert DA_InsufficientCash();
+
     // risk manager transfers portion of the account to the bidder, liquidator pays cash to accountId
     ILiquidatableManager(address(subAccounts.manager(accountId))).executeBid(
       accountId, bidderId, convertedPercentage, cashFromBidder, currentAuction.reservedCash

--- a/test/auction/unit-tests/DutchAuctionBase.sol
+++ b/test/auction/unit-tests/DutchAuctionBase.sol
@@ -32,7 +32,10 @@ contract DutchAuctionBase is Test {
 
   function setUp() public {
     _deployMockSystem();
+
     _setupAccounts();
+    // bob is the main liquidator in our test: give him 20K cash
+    _mintAndDepositCash(bobAcc, 20_000e18);
 
     dutchAuction = new DutchAuction(subAccounts, sm, usdcAsset);
 
@@ -64,20 +67,10 @@ contract DutchAuctionBase is Test {
     sm.createAccountForSM(manager);
   }
 
-  function _mintAndDeposit(
-    address user,
-    uint accountId,
-    MockERC20 token,
-    MockAsset assetWrapper,
-    uint subId,
-    uint amount
-  ) public {
-    token.mint(user, amount);
-
-    vm.startPrank(user);
-    token.approve(address(assetWrapper), type(uint).max);
-    assetWrapper.deposit(accountId, subId, amount);
-    vm.stopPrank();
+  function _mintAndDepositCash(uint accountId, uint amount) public {
+    usdc.mint(address(this), amount);
+    usdc.approve(address(usdcAsset), type(uint).max);
+    usdcAsset.deposit(accountId, amount);
   }
 
   function _setupAccounts() public {

--- a/test/auction/unit-tests/SolventAuction.t.sol
+++ b/test/auction/unit-tests/SolventAuction.t.sol
@@ -115,8 +115,18 @@ contract UNIT_TestSolventAuction is DutchAuctionBase {
     assertEq(auction.insolvent, false);
   }
 
+  function testCannotBidWithNoCash() public {
+    _startDefaultSolventAuction(aliceAcc);
+
+    // bid from charlie with no cash
+    vm.prank(charlie);
+    vm.expectRevert(IDutchAuction.DA_InsufficientCash.selector);
+    dutchAuction.bid(aliceAcc, charlieAcc, 1e18);
+  }
+
   function testBidRaceCondition() public {
     _startDefaultSolventAuction(aliceAcc);
+    _mintAndDepositCash(charlieAcc, 20_000e18);
 
     // fast forward to half way through the fast auction
     vm.warp(block.timestamp + _getDefaultSolventParams().fastAuctionLength / 2);


### PR DESCRIPTION
## Summary
Bug description: in our previous implementation, there is no requirement on how much cash an account is holding, meaning someone can bid on their own account with 0 cash, effectively restarting the liquidation with no more USDC backing the portfolio. 

## Solution
Add checks on whether the bidder has enough cash to bid on an auction.
