### PR TITLE
remove the settlement start check, as 0 values should be allowed

### DIFF
--- a/src/feeds/LyraForwardFeed.sol
+++ b/src/feeds/LyraForwardFeed.sol
@@ -182,8 +182,7 @@ contract LyraForwardFeed is BaseLyraFeed, ILyraForwardFeed, IForwardFeed, ISettl
   }
 
   function _verifySettlementDataValid(uint settlementStartAggregate, uint currentSpotAggregate) internal pure {
-    if (settlementStartAggregate == 0 || currentSpotAggregate == 0 || settlementStartAggregate >= currentSpotAggregate)
-    {
+    if (settlementStartAggregate >= currentSpotAggregate) {
       revert LFF_InvalidSettlementData();
     }
   }

--- a/test/feed/unit-tests/LyraForwardFeed.t.sol
+++ b/test/feed/unit-tests/LyraForwardFeed.t.sol
@@ -248,7 +248,7 @@ contract UNIT_LyraForwardFeed is LyraFeedTestUtils {
 
     uint newCurAggregate = 0;
     feedData.data =
-      abi.encode(defaultExpiry, newCurAggregate, currentSpotAggregate, fwdSpotDifference, defaultConfidence);
+      abi.encode(defaultExpiry, settlementStartAggregate, newCurAggregate, fwdSpotDifference, defaultConfidence);
     bytes memory data = _signFeedData(feed, pk, feedData);
 
     vm.expectRevert(ILyraForwardFeed.LFF_InvalidSettlementData.selector);


### PR DESCRIPTION
## Summary

remove the settlement start check, as 0 values should be allowed

Theres an argument to be made that the "fixed" portion of the feed could begin at 0 and then have the "current" value grow with time. Might simplify certain implementations.