### PR TITLE
Allow perp cap to be adjustable

### DIFF
--- a/src/interfaces/ILyraSpotDiffFeed.sol
+++ b/src/interfaces/ILyraSpotDiffFeed.sol
@@ -16,10 +16,12 @@ interface ILyraSpotDiffFeed is IBaseLyraFeed {
   //       Events       //
   ////////////////////////
   event SpotFeedUpdated(ISpotFeed spotFeed);
+  event SpotDiffCapUpdated(uint spotDiffCap);
   event SpotDiffUpdated(int96 spotDiff, uint96 confidence, uint64 timestamp);
 
   ////////////////////////
   //       Errors       //
   ////////////////////////
+  error LSDF_InvalidSpotDiffCap();
   error LSDF_InvalidConfidence();
 }


### PR DESCRIPTION
## Summary

Due to potential issues around max leverage and feed manipulation, it makes sense to make these bounds adjustable. The higher the leverage allowed, the tighter these bounds should be.

Also change the multiplicative property to be an absolute value of param * spot as the cap (*-1 for negative), rather than param / spot for the negative side