### PR TITLE
Make max expiries only increasing

### DIFF
--- a/src/risk-managers/PMRM.sol
+++ b/src/risk-managers/PMRM.sol
@@ -97,7 +97,7 @@ contract PMRM is IPMRM, ILiquidatableManager, BaseManager, ReentrancyGuard {
    * @dev set max tradeable expiries in a single account
    */
   function setMaxExpiries(uint _maxExpiries) external onlyOwner {
-    if (_maxExpiries < 6 || _maxExpiries > 30) {
+    if (_maxExpiries <= maxExpiries || _maxExpiries > 30) {
       revert PMRM_InvalidMaxExpiries();
     }
     maxExpiries = _maxExpiries;

--- a/test/risk-managers/unit-tests/PMRM/TestPMRM_Admin.t.sol
+++ b/test/risk-managers/unit-tests/PMRM/TestPMRM_Admin.t.sol
@@ -282,16 +282,20 @@ contract TestPMRM_Admin is PMRMTestBase {
 
   function testCannotSetInvalidMaxExpiries() public {
     vm.expectRevert(IPMRM.PMRM_InvalidMaxExpiries.selector);
-    pmrm.setMaxExpiries(1);
+    pmrm.setMaxExpiries(11);
 
     vm.expectRevert(IPMRM.PMRM_InvalidMaxExpiries.selector);
     pmrm.setMaxExpiries(31);
+
+    pmrm.setMaxExpiries(15);
+    vm.expectRevert(IPMRM.PMRM_InvalidMaxExpiries.selector);
+    pmrm.setMaxExpiries(15);
   }
 
   function testCanSetMaxExpiries() public {
-    pmrm.setMaxExpiries(10);
+    pmrm.setMaxExpiries(12);
 
-    assertEq(pmrm.maxExpiries(), 10);
+    assertEq(pmrm.maxExpiries(), 12);
   }
 
   function testCannotSetInvalidMaxSize() public {


### PR DESCRIPTION
## Summary

There is a potential lock to liquidations if risk cannot be computed if max expiries were to ever decrease. To prevent this, make it so that max expiries can only be increased.