### PR TITLE
Chore fix typos

### DIFF
--- a/src/interfaces/IPMRMLib.sol
+++ b/src/interfaces/IPMRMLib.sol
@@ -41,7 +41,7 @@ interface IPMRMLib {
     uint basePercent;
     /// @dev Contingency applied to perps held in the portfolio, multiplied by spot.
     uint perpPercent;
-    /// @dev Factor for multiplying number of naked shorts (per strike) in the portfolio, multipled by spot.
+    /// @dev Factor for multiplying number of naked shorts (per strike) in the portfolio, multiplied by spot.
     uint optionPercent;
   }
 

--- a/test/account/unit-tests/Permit.t.sol
+++ b/test/account/unit-tests/Permit.t.sol
@@ -292,7 +292,7 @@ contract UNIT_AccountPermit is Test, AccountTestBase {
     // depost 1000 coolToken for account2
     mintAndDeposit(alice, accountId2, coolToken, coolAsset, tokenSubId, tradeAmount);
 
-    // premits and signature arrays
+    // permits and signature arrays
     IAllowances.PermitAllowance[] memory permits = new IAllowances.PermitAllowance[](2);
     bytes[] memory signatures = new bytes[](2);
 


### PR DESCRIPTION
## Chore: Fix Typos


1. **File**: `src/interfaces/IPMRMLib.sol`  
   - Corrected a typo in the comment, changing **"multipled"** to **"multiplied"**.

2. **File**: `test/account/unit-tests/Permit.t.sol`  
   - Fixed a typo in the comment, changing **"premits"** to **"permits"**.

-